### PR TITLE
Don't query level 1-0

### DIFF
--- a/CensusPlusClassic.lua
+++ b/CensusPlusClassic.lua
@@ -1589,12 +1589,12 @@ function CensusPlus_DumpJob(job)
 	end
 
 	local minLevel = job.m_MinLevel
-	if (minLevel ~= nil) then
+	if (minLevel ~= nil and minLevel ~= 0) then
 		whoText = whoText .. " min: " .. minLevel
 	end
 
 	local maxLevel = job.m_MaxLevel
-	if (maxLevel ~= nil) then
+	if (maxLevel ~= nil and maxLevel ~= 0) then
 		whoText = whoText .. " max: " .. maxLevel
 	end
 


### PR DESCRIPTION
The census was generating many (hundreds/over a thousand) queries for levels 1-0 which don't return any results and just end up being completely wasted time/processing power. Added a guard to not generate the queries for this case. Tested and it finishes at level 1s.