### PR TITLE
"1-0" bug fix in CP_ProcessWhoEvent()

### DIFF
--- a/CensusPlusClassic.lua
+++ b/CensusPlusClassic.lua
@@ -562,7 +562,7 @@ function CP_ProcessWhoEvent(query, result, complete)
 		local zoneLetter = g_CurrentJob.m_zoneLetter
 		local letter = g_CurrentJob.m_Letter
 
-		if (minLevel ~= maxLevel and minLevel ~= 0) then
+		if (minLevel < maxLevel) then
 			-- The level range is greater than a single level, so split it in half and submit the two jobs
 			local pivot = floor((minLevel + maxLevel) / 2)
 			local jobLower =


### PR DESCRIPTION
Fix to the algorithm that splits a level bracket into two narrower brackets if query results >= 50.