### PR TITLE
Added possibility to manually send who requests

### DIFF
--- a/CensusPlusClassic.lua
+++ b/CensusPlusClassic.lua
@@ -509,6 +509,13 @@ function CensusPlus_OnLoad(self)
 	--  Set up an empty frame for updates
 	local updateFrame = CreateFrame("Frame")
 	updateFrame:SetScript("OnUpdate", CensusPlus_OnUpdate)
+	
+	SetBindingClick("SHIFT-T", CensusPlusWhoButton:GetName())
+	CensusPlusWhoButton:SetScript("OnClick", function(self, button, down)
+	-- As we have not specified the button argument to SetBindingClick,
+	-- the binding will be mapped to a LeftButton click.
+		ManualWho()
+	end)
 end
 
 
@@ -1176,6 +1183,17 @@ function CENSUSPLUS_STOP_OnEnter(self, motion)
 	end
 end
 
+-- referenced by CensusPlusClassic.xml
+function CENSUSPLUS_MANUALWHO_OnEnter(self, motion)
+	if (motion == true) then
+		GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+		GameTooltip:SetText("Issues manual who request.", 1.0, 1.0, 1.0)
+		GameTooltip:Show()
+	-- frame created underneath cursor.. not cursor movement to frame
+	else
+	end
+end
+
 
 function CensusPlus_TimerSet(self, minutes, ovrride)
 	if minutes == nil then
@@ -1458,6 +1476,11 @@ function CENSUSPLUS_STOPCENSUS()
 	-- Add revert CensusButton back to defauit
 	CensusButton:SetNormalFontObject(GameFontNormal)
 	CensusButton:SetText("C+")
+end
+
+function CENSUSPLUS_MANUALWHO()
+	print("istsecure() = ", issecure())
+	ManualWho()
 end
 
 -- Display Census results
@@ -3528,6 +3551,23 @@ function CensusPlus_CheckTZ()
 	g_CensusPlusTZOffset = servDiff
 end
 
+local whoMsg
+
+function ManualWho()
+	if (g_Verbose == true) then
+		print("ManualWho:", whoMsg)
+	end
+	if (whoquery_active) then
+		wholib:Who(whoMsg, {
+			queue = wholib.WHOLIB_QUEUE_QUIET,
+			flags = 0,
+			callback = CP_ProcessWhoEvent
+		})
+		WhoFrameEditBox:SetText(whoMsg)
+		WhoFrameWhoButton:Click()
+	end
+end
+
 function CensusPlus_SendWho(msg)
 	if (g_Verbose == true) then
 		CensusPlus_Msg(format(CENSUSPLUS_SENDING, msg))
@@ -3549,14 +3589,17 @@ function CensusPlus_SendWho(msg)
 	end
 
 	if wholib then
-		wholib:Who(msg, {
-			queue = wholib.WHOLIB_QUEUE_QUIET,
-			flags = 0,
-			callback = CP_ProcessWhoEvent
-		})
+		whoMsg = msg
+		--wholib:Who(msg, {
+		--	queue = wholib.WHOLIB_QUEUE_QUIET,
+		--	flags = 0,
+		--	callback = CP_ProcessWhoEvent
+		--})
 		--wholib:AskWho({query = msg, queue = wholib.WHOLIB_QUEUE_QUIET, callback = CP_ProcessWhoEvent })
 	else
-		SendWho(msg)
+		--SendWho(msg)
+		--ManualWho(msg)
+		whoMsg = msg
 	end
 	whoquery_active = true
 	CP_g_queue_count = CP_g_queue_count + 1

--- a/CensusPlusClassic.xml
+++ b/CensusPlusClassic.xml
@@ -958,6 +958,25 @@
 										</OnLeave>
                 </Scripts>
             </Button>
+            <Button name="CensusPlusWhoButton" inherits="UIPanelButtonTemplate" text="ManualWho">
+                <Size>
+                    <AbsDimension x="128" y="21" />
+                </Size>
+                <Anchors>
+                    <Anchor point="TOPLEFT" relativeTo="CensusPlusTakeButton" >
+                        <Offset>
+                            <AbsDimension x="265" y="0" />
+                        </Offset>
+                    </Anchor>
+                </Anchors>
+                <Scripts>
+                    <OnClick function="CENSUSPLUS_MANUALWHO" />
+                    <OnEnter function="CENSUSPLUS_MANUALWHO_OnEnter" />
+                    <OnLeave>
+                        GameTooltip:Hide();
+                    </OnLeave>
+                </Scripts>
+            </Button>
             <Button name="CensusPlusPruneButton" inherits="UIPanelButtonTemplate" text="CENSUSPLUS_PRUNE">
                 <Size>
                     <AbsDimension x="128" y="21" />

--- a/libs/LibWho-2.0/LibWho-2.0.lua
+++ b/libs/LibWho-2.0/LibWho-2.0.lua
@@ -477,7 +477,7 @@ function lib:AskWhoNext()
 		end
 
 		dbg("QUERY: "..args.query)
-		self.hooked.SendWho(args.query)
+		--self.hooked.SendWho(args.query)
 	else
 		self.Args = nil
 		self.WhoInProgress = false
@@ -785,7 +785,7 @@ SLASH_WHOLIB_DEBUG1 = '/wholibdebug'
 
 -- functions to hook
 local hooks = {
-	'WhoFrameEditBox_OnEnterPressed',
+--	'WhoFrameEditBox_OnEnterPressed',
 --	'FriendsFrame_OnEvent',
 }
 
@@ -802,7 +802,7 @@ end -- for
 
 -- C_FriendList functions to hook
 local CFL_hooks = {
-	'SendWho',
+--	'SendWho',
 	'SetWhoToUi',
 }
 


### PR DESCRIPTION
I played a bit around and built in the possibility to manually send who requests either with a manual who button in the user interface, or via keyboard by pressing SHIFT+T. It's not the best solution but at least, we can gather data again now.