### PR TITLE
added throttling to the manual calls

### DIFF
--- a/CensusPlusClassic.lua
+++ b/CensusPlusClassic.lua
@@ -3555,8 +3555,8 @@ local whoMsg
 local lastManual = GetTime()
 
 function ManualWho()
-	local now = GetTime();
-	local deltaManual = now - lastManual;
+	local now = GetTime()
+	local deltaManual = now - lastManual
 	if  (deltaManual > CensusPlus_UPDATEDELAY2) then
 		if (g_Verbose == true) then
 			print("ManualWho:", whoMsg)
@@ -3570,6 +3570,7 @@ function ManualWho()
 			WhoFrameEditBox:SetText(whoMsg)
 			WhoFrameWhoButton:Click()
 		end
+		lastManual = GetTime()
 	end
 end
 

--- a/CensusPlusClassic.lua
+++ b/CensusPlusClassic.lua
@@ -3552,19 +3552,24 @@ function CensusPlus_CheckTZ()
 end
 
 local whoMsg
+local lastManual = GetTime()
 
 function ManualWho()
-	if (g_Verbose == true) then
-		print("ManualWho:", whoMsg)
-	end
-	if (whoquery_active) then
-		wholib:Who(whoMsg, {
-			queue = wholib.WHOLIB_QUEUE_QUIET,
-			flags = 0,
-			callback = CP_ProcessWhoEvent
-		})
-		WhoFrameEditBox:SetText(whoMsg)
-		WhoFrameWhoButton:Click()
+	local now = GetTime();
+	local deltaManual = now - lastManual;
+	if  (deltaManual > CensusPlus_UPDATEDELAY2) then
+		if (g_Verbose == true) then
+			print("ManualWho:", whoMsg)
+		end
+		if (whoquery_active) then
+			wholib:Who(whoMsg, {
+				queue = wholib.WHOLIB_QUEUE_QUIET,
+				flags = 0,
+				callback = CP_ProcessWhoEvent
+			})
+			WhoFrameEditBox:SetText(whoMsg)
+			WhoFrameWhoButton:Click()
+		end
 	end
 end
 


### PR DESCRIPTION
If you bind `run ManualWho()` to combat abilities, it may be called to often. This change adds some throttling.

cc @Ceron257 

#24 already includes the throttle