### PR TITLE
Introduction of experimental feature for semi-automatic who requests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.tabSize": 2,
+  "editor.useTabStops": false,
+  "editor.detectIndentation": false
+}

--- a/CensusPlusClassic.lua
+++ b/CensusPlusClassic.lua
@@ -2414,6 +2414,7 @@ function CensusPlus_ProcessWhoResults(result, numWhoResults)
 		local tmpGldend = nil
 		local relationship = nil
 		if (CensusPlus_WHOPROCESSOR == CP_libwho) then
+			if (result[i] == nil) then return end
 			name = result[i].Name
 			realm = CensusPlus_GetUniqueRealmName()
 			guild = result[i].Guild
@@ -3598,7 +3599,6 @@ function ManualWho()
 			})
 			WhoFrameEditBox:SetText(whoMsg)
 			WhoFrameWhoButton:Click()
-			WhoFrame:GetParent():Hide()
 		end
 	end
 end

--- a/CensusPlusClassic.lua
+++ b/CensusPlusClassic.lua
@@ -3555,8 +3555,8 @@ local whoMsg
 local lastManual = GetTime()
 
 function ManualWho()
-	local now = GetTime();
-	local deltaManual = now - lastManual;
+	local now = GetTime()
+	local deltaManual = now - lastManual
 	if  (deltaManual > CensusPlus_UPDATEDELAY2) then
 		if (g_Verbose == true) then
 			print("ManualWho:", whoMsg)
@@ -3570,6 +3570,7 @@ function ManualWho()
 			WhoFrameEditBox:SetText(whoMsg)
 			WhoFrameWhoButton:Click()
 		end
+		lastManual = GetTime()
 	end
 end
 

--- a/CensusPlusClassic.lua
+++ b/CensusPlusClassic.lua
@@ -1424,7 +1424,7 @@ function CensusPlus_StartCensus()
 			wholib = wholib or LibStub:GetLibrary("LibWho-2.0", true)
 			if wholib then
 				CensusPlus_Msg(CENSUSPLUS_USING_WHOLIB)
-				CensusPlus_UPDATEDELAY = 60
+				--CensusPlus_UPDATEDELAY = 60
 			end
 		end
 	end
@@ -3585,22 +3585,23 @@ end
 local whoMsg
 
 function ManualWho()
-	now = time()
-	if now - CPp.LastManualWho > 5 then
-		if (g_Verbose == true) then
-			print("ManualWho:", whoMsg)
-		end
-		CPp.LastManualWho = time()
-		if (whoquery_active) then
-			wholib:Who(whoMsg, {
-				queue = wholib.WHOLIB_QUEUE_QUIET,
-				flags = 0,
-				callback = CP_ProcessWhoEvent
-			})
-			WhoFrameEditBox:SetText(whoMsg)
-			WhoFrameWhoButton:Click()
-		end
-	end
+  now = time()
+  local deltaManual = now - CPp.LastManualWho
+  if deltaManual > CensusPlus_UPDATEDELAY then
+    if (g_Verbose == true) then
+      print("ManualWho:", whoMsg)
+    end
+    CPp.LastManualWho = time()
+    if (whoquery_active) then
+      wholib:Who(whoMsg, {
+        queue = wholib.WHOLIB_QUEUE_QUIET,
+        flags = 0,
+        callback = CP_ProcessWhoEvent
+      })
+      WhoFrameEditBox:SetText(whoMsg)
+      WhoFrameWhoButton:Click()
+    end
+  end
 end
 
 function CensusPlus_SendWho(msg)

--- a/CensusPlusClassic.lua
+++ b/CensusPlusClassic.lua
@@ -3552,19 +3552,24 @@ function CensusPlus_CheckTZ()
 end
 
 local whoMsg
+local lastManual = GetTime()
 
 function ManualWho()
-	if (g_Verbose == true) then
-		print("ManualWho:", whoMsg)
-	end
-	if (whoquery_active) then
-		wholib:Who(whoMsg, {
-			queue = wholib.WHOLIB_QUEUE_QUIET,
-			flags = 0,
-			callback = CP_ProcessWhoEvent
-		})
-		WhoFrameEditBox:SetText(whoMsg)
-		WhoFrameWhoButton:Click()
+	local now = GetTime();
+	local deltaManual = now - lastManual;
+	if  (deltaManual > CensusPlus_UPDATEDELAY2) then
+		if (g_Verbose == true) then
+			print("ManualWho:", whoMsg)
+		end
+		if (whoquery_active) then
+			wholib:Who(whoMsg, {
+				queue = wholib.WHOLIB_QUEUE_QUIET,
+				flags = 0,
+				callback = CP_ProcessWhoEvent
+			})
+			WhoFrameEditBox:SetText(whoMsg)
+			WhoFrameWhoButton:Click()
+		end
 	end
 end
 

--- a/CensusPlusClassic.lua
+++ b/CensusPlusClassic.lua
@@ -2860,7 +2860,7 @@ function CensusPlus_UpdateView()
 		
 		if( CensusPlus_EnableProfiling ) then
 			CensusPlus_Msg( "PROFILE: Time to do calcs 1 " .. debugprofilestop() / 1000000000 );
-			debugprofilestart();
+			--debugprofilestart();
 		end
 		
 	else
@@ -2871,7 +2871,7 @@ function CensusPlus_UpdateView()
 		
 		if( CensusPlus_EnableProfiling ) then
 			CensusPlus_Msg( "PROFILE: Time to do calcs 1 " .. debugprofilestop() / 1000000000 );
-			debugprofilestart();
+			--debugprofilestart();
 		end
 		
 		local size = table.getn(CensusPlus_Guilds);
@@ -2881,7 +2881,7 @@ function CensusPlus_UpdateView()
 		
 		if( CensusPlus_EnableProfiling ) then
 			CensusPlus_Msg( "PROFILE: Time to sort guilds " .. debugprofilestop() / 1000000000 );
-			debugprofilestart();
+			--debugprofilestart();
 		end			
 	end
 	
@@ -2908,7 +2908,7 @@ function CensusPlus_UpdateView()
 	
 	if( CensusPlus_EnableProfiling ) then
 		CensusPlus_Msg( "PROFILE: Update Guilds " .. debugprofilestop() / 1000000000 );
-		debugprofilestart();
+		--debugprofilestart();
 	end
 
 	-- Accumulate totals for each race
@@ -2954,7 +2954,7 @@ function CensusPlus_UpdateView()
 
 	if( CensusPlus_EnableProfiling ) then
 		CensusPlus_Msg( "PROFILE: Update Races " .. debugprofilestop() / 1000000000 );
-		debugprofilestart();
+		--debugprofilestart();
 	end
 
 	-- Accumulate totals for each class
@@ -3002,7 +3002,7 @@ function CensusPlus_UpdateView()
 
 	if( CensusPlus_EnableProfiling ) then
 		CensusPlus_Msg( "PROFILE: Update Classes " .. debugprofilestop() / 1000000000 );
-		debugprofilestart();
+		--debugprofilestart();
 	end
 
 	-- Accumulate totals for each level
@@ -3046,7 +3046,7 @@ function CensusPlus_UpdateView()
 	
 	if( CensusPlus_EnableProfiling ) then
 		CensusPlus_Msg( "PROFILE: Update Levels " .. debugprofilestop() / 1000000000 );
-		debugprofilestart();	
+		--debugprofilestart();	
 	end
 	
 	if( CP_PlayerListWindow:IsVisible() ) then

--- a/libs/LibWho-2.0/LibWho-2.0.lua
+++ b/libs/LibWho-2.0/LibWho-2.0.lua
@@ -755,19 +755,19 @@ end
 --- slash commands
 ---
 
-SlashCmdList['WHO'] = function(msg)
-	dbg("console /who: "..msg)
-	-- new /who function
-	--local self = lib
-	
-	if(msg == '')then
-		lib:GuiWho(WhoFrame_GetDefaultWhoCommand())
-	elseif(WhoFrame:IsVisible())then
-		lib:GuiWho(msg)
-	else
-		lib:ConsoleWho(msg)
-	end
-end
+--SlashCmdList['WHO'] = function(msg)
+--	dbg("console /who: "..msg)
+--	-- new /who function
+--	--local self = lib
+--	
+--	if(msg == '')then
+--		lib:GuiWho(WhoFrame_GetDefaultWhoCommand())
+--	elseif(WhoFrame:IsVisible())then
+--		lib:GuiWho(msg)
+--	else
+--		lib:ConsoleWho(msg)
+--	end
+--end
 	
 SlashCmdList['WHOLIB_DEBUG'] = function()
 	-- /wholibdebug: toggle debug on/off
@@ -918,8 +918,8 @@ FriendsFrame:UnregisterEvent("WHO_LIST_UPDATE")
 
 function lib:WHO_LIST_UPDATE()
     if not lib.Quiet then
-		WhoList_Update()		
-        FriendsFrame_Update()
+      WhoList_Update()
+      FriendsFrame_Update()
     end
 
     lib:ProcessWhoResults()

--- a/modules/CensusPlayerList.lua
+++ b/modules/CensusPlayerList.lua
@@ -45,7 +45,7 @@ end
 
 function CensusPlus_PlayerListOnShow()
 
-	debugprofilestart();
+	--debugprofilestart();
 	
 	local guildKey = nil;
 	local raceKey = nil;
@@ -90,13 +90,13 @@ function CensusPlus_PlayerListOnShow()
 		levelKey = g_LevelSelected;
 	end
 
-	debugprofilestart();
+	--debugprofilestart();
 
 	CensusPlus_ForAllCharacters( realmName, factionGroup, raceKey, classKey, guildKey, levelKey, CensusPlus_AddPlayerToList);
 		
 	if( CensusPlus_EnableProfiling ) then
 		CensusPlus_Msg( "PROFILE: Time to do calcs 1 " .. debugprofilestop() / 1000000000 );
-		debugprofilestart();
+		--debugprofilestart();
 	end
 		
 
@@ -107,7 +107,7 @@ function CensusPlus_PlayerListOnShow()
 	
 	local totalCharactersText = format(CENSUSPLUS_TOTALCHAR, table.getn( g_PlayerList ) );
 	if( table.getn( g_PlayerList ) == g_MaxNumListed ) then
-		totalCharactersText = totalCharactersText .. " -- " .. CENSUSPlus_MAXXED;
+		totalCharactersText = totalCharactersText .. " -- " .. CENSUSPLUS_MAXXED;
 	end
 	
 	CensusPlayerListCount:SetText(totalCharactersText);


### PR DESCRIPTION
I played around a bit and introduced two experimental features:

* trigger who request on **mouse clicks in the 3D window** (like turning the camera with mouse, interacting with things in the world, clicking players, loot mobs etc.)
* trigger who requests on **mouse clicks of most of the clickable buttons in the interface** (this includes action bars as well, so no macros are needed to issue who requests by simply casting with the mouse)

Both features require a UI reload before they will work. Unfortunately I did not figure out a way to do the same for keyboard events. But I think the first option to use the mouse is totally sufficient for now! 😉 

Beside that I removed wholib's /who command, so that the blizzard UI may handle that command correctly. However the normal who functionality still doesn't work correctly (e.g. Shift+LMB on player names shows the who window instead of simply printing the information in the chat window).

**Note**: My database got somehow deleted while developing this. I am not sure if it's connected to the changes or if something different happened.
